### PR TITLE
Update StraferV3 DriveConstants

### DIFF
--- a/docs/.vuepress/components/DriveConstants/ConstantsGenerator.ts
+++ b/docs/.vuepress/components/DriveConstants/ConstantsGenerator.ts
@@ -50,7 +50,7 @@ const StraferV3Constants: ConstantProperties = {
   wheelRadius: 1.88976,
   gearRatio: 1,
 
-  trackWidth: 14.8,
+  trackWidth: 16.34,
 
   recommendedVelo: (312 / 60) * 1.88976 * 2 * Math.PI * 0.85,
   recommendedAccel: (312 / 60) * 1.88976 * 2 * Math.PI * 0.85,


### PR DESCRIPTION
Track width in DriveConstants generator is wrong. See [GoBilda's website](https://www.gobilda.com/strafer-chassis-kit/). 453mm - 38mm (wheel width) = 415mm = 16.34in