### PR TITLE
Generalize to be game inspecific

### DIFF
--- a/docs/markers.md
+++ b/docs/markers.md
@@ -1,6 +1,6 @@
 # Marker Guide
 
-Alright so you got trajectories down. But you're in a robot competition and you're here to win! Your bot has to do more than simply drive around. You gotta turn on motors and lift servos and shoot blocks. How do we accomplish that?
+Alright so you got trajectories down. But you're in a robot competition and you're here to win! Your bot has to do more than simply drive around. You gotta turn on motors and lift servos and interact with elements. How do we accomplish that?
 
 Road Runner as a handy little feature called markers. These allow you to run actions along your path.
 


### PR DESCRIPTION
An earlier PR was declined because it isn't feasible to update this line every year to be accurate with each year's game. However, I believe that it may confuse new FTC team members (even if the team uses RR already, a new member may be new to using it) to reference something that isn't in the current year's game.

It is completely safe to assume every FTC game going forward will have *some* sort of game element, so generalizing this line to reference interacting with elements is the better way to go, in my opinion.

Kind of a small thing but small contributions is what open source is all about, isn't it?