### PR TITLE
Removed a typo in the intalling.md

### DIFF
--- a/docs/installing.md
+++ b/docs/installing.md
@@ -168,7 +168,7 @@ dependencies {
 ├── <span class="file">gradlew.bat</span>
 └── <span class="file">settings.gradle</span>
 
-├── <span class="file">`build.dependencies.gradle` _(**This one**)_</span>
+├── <span class="file">build.dependencies.gradle</span>
 ├── <span class="file">build.gradle</span>
 ├── <span class="file">gradle.properties</span>
 ├── <span class="file">gradlew</span>


### PR DESCRIPTION
While working on the previous commit for installing.md, I forgot to take out the highlight for a unwanted to line.